### PR TITLE
Document RIDER sync and fix smoke metric mock

### DIFF
--- a/coolprompt/optimizer/rider/README.md
+++ b/coolprompt/optimizer/rider/README.md
@@ -39,6 +39,11 @@ package. The CoolPrompt wrapper supplies user train/validation data through
 RIDER context hooks and external validation reranking, so the optimizer adapts
 to the user's dataset without copying the research benchmark stack.
 
+The copied core is synced with the current RIDER Genesis Ultra implementation
+from the RIDER research repository. CoolPrompt-specific additions are limited
+to the LangChain runtime shim, train/validation context injection, external
+validation reranking, and public hyperparameter forwarding.
+
 ## Prompt Templates
 
 RIDER Genesis Ultra meta-prompts live in

--- a/test/coolprompt/optimizer/test_smoke_optimizer_interface.py
+++ b/test/coolprompt/optimizer/test_smoke_optimizer_interface.py
@@ -91,6 +91,10 @@ def test_prompt_tuner_runs_rider_method(monkeypatch):
             self.calls.append((prompt, dataset, targets, template, kwargs))
             return 1.0 if "optimized" in prompt else 0.0
 
+    class _FakeMetric:
+        def _get_name(self):
+            return "bertscore"
+
     class _FakeRule:
         def __init__(self, model):
             self.model = model
@@ -110,7 +114,7 @@ def test_prompt_tuner_runs_rider_method(monkeypatch):
     monkeypatch.setattr("coolprompt.assistant.TaskDetector", _FakeTaskDetector)
     monkeypatch.setattr(
         "coolprompt.assistant.validate_and_create_metric",
-        lambda *args, **kwargs: object(),
+        lambda *args, **kwargs: _FakeMetric(),
     )
     monkeypatch.setattr("coolprompt.assistant.Evaluator", _FakeEvaluator)
     monkeypatch.setattr("coolprompt.assistant.LanguageRule", _FakeRule)


### PR DESCRIPTION
## Summary
- Updated the RIDER Genesis Ultra integration branch on top of the latest `stage`.
- Documented that the copied RIDER core is synced with the current RIDER Genesis Ultra implementation.
- Kept CoolPrompt-specific integration limited to LangChain runtime shim, train/validation context injection, external validation reranking, and hyperparameter forwarding.
- Fixed the RIDER smoke test mock for the current metric API.

## Checks
- `python -m pytest test/coolprompt/optimizer/rider test/coolprompt/optimizer/test_smoke_optimizer_interface.py -q`
- Real small end-to-end run through `PromptTuner.run(..., method="rider")` with train/validation data and RIDER hyperparameters.