### PR TITLE
multiref bertscore & commongen multilabel loading

### DIFF
--- a/coolprompt/assistant.py
+++ b/coolprompt/assistant.py
@@ -137,6 +137,7 @@ class PromptTuner:
         llm_as_judge_criteria: str | list[str] = "relevance",
         llm_as_judge_custom_templates: Optional[dict[str, str]] = None,
         llm_as_judge_metric_ceil: int = 10,
+        bertscore_model_type: Optional[str] = None,
         geval_criteria: Optional[str] = None,
         geval_evaluation_steps: Optional[list[str]] = None,
         geval_evaluation_params: Optional[list] = None,
@@ -189,6 +190,8 @@ class PromptTuner:
                 prompt templates for each criterion.
             llm_as_judge_metric_ceil (int): Maximum integer score expected
                 from the judge (1..ceil); normalized to [0,1].
+            bertscore_model_type (str | None): Optional HF ``model_type`` for
+                `bertscore` and `multiref_bertscore`.
             geval_criteria (str | None): High‑level description for GEval.
                 Mutually exclusive with `geval_evaluation_steps`.
             geval_evaluation_steps (list[str] | None): Step‑by‑step
@@ -248,6 +251,7 @@ class PromptTuner:
             llm_as_judge_criteria=llm_as_judge_criteria,
             llm_as_judge_custom_templates=llm_as_judge_custom_templates,
             llm_as_judge_metric_ceil=llm_as_judge_metric_ceil,
+            bertscore_model_type=bertscore_model_type,
             geval_criteria=geval_criteria,
             geval_evaluation_steps=geval_evaluation_steps,
             geval_evaluation_params=geval_evaluation_params,
@@ -366,6 +370,7 @@ class PromptTuner:
         task: Optional[str] = None,
         targets: Optional[Iterable[str | int]] = None,
         metric: Optional[str] = None,
+        bertscore_model_type: Optional[str] = None,
         batch_size: int = 25,
         return_raw_outputs: bool = True,
     ) -> List[str] | Tuple[List[str], float]:
@@ -387,6 +392,8 @@ class PromptTuner:
                 If provided, metric is computed and returned.
             metric (Optional[str]): Metric name. If None, defaults to "accuracy"
                 for classification or "bertscore" for generation.
+            bertscore_model_type (Optional[str]): Optional HF ``model_type``
+                for `bertscore` and `multiref_bertscore`.
             batch_size (int, default=25): Number of samples per inference batch.
             return_raw_outputs (bool, default=True): If True, return raw model outputs;
                 if False, return parsed outputs via metric.parse_output().
@@ -418,7 +425,11 @@ class PromptTuner:
         if metric is None:
             metric = "accuracy" if task_enum == Task.CLASSIFICATION else "meteor"
         
-        metric_impl = validate_and_create_metric(task_enum, metric)
+        metric_impl = validate_and_create_metric(
+            task_enum,
+            metric,
+            bertscore_model_type=bertscore_model_type,
+        )
         
         evaluator = Evaluator(
             model=self._target_model,

--- a/coolprompt/evaluator/metrics.py
+++ b/coolprompt/evaluator/metrics.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 import re
-from typing import Optional, Dict, List, Tuple
+from typing import Optional, Dict, List, Tuple, Sequence
 
 from deepeval.metrics import GEval
 from deepeval.test_case import LLMTestCase, LLMTestCaseParams
@@ -394,6 +394,98 @@ class BertScoreMetric(HFEvaluateMetric, GenerationMetric):
             "model_type": "bert-base-multilingual-cased"
         }
         self._return_parameter = "f1"
+
+
+class MultiReferenceBertScoreMetric(HFEvaluateMetric, GenerationMetric):
+    """BERTScore F1 with max-over-references for multi-reference targets."""
+
+    @staticmethod
+    def _get_name():
+        return "multiref_bertscore"
+
+    def __init__(self):
+        """Load BERTScore with the multilingual base model."""
+        super().__init__("bertscore")
+        self._compute_kwargs_func = lambda outputs, targets: {
+            "model_type": "bert-base-multilingual-cased"
+        }
+        self._return_parameter = "f1"
+
+    def compute(
+        self,
+        outputs: list[str | int],
+        targets: list[str | Sequence[str]],
+        dataset: Optional[list[str]] = None,
+        failed_examples: Optional[int] = None,
+        return_per_task: bool = False,
+    ) -> object:
+        """Compute mean max BERTScore over references for each output.
+
+        This method intentionally does not call ``BaseMetric.compute`` because
+        that generic path stringifies every target and would collapse a list of
+        references into a single string.
+        """
+        parsed_outputs = [
+            extract_answer(output, self.ANS_TAGS, format_mismatch_label=output)
+            for output in outputs
+        ]
+
+        results = self._compute_scores(parsed_outputs, targets)
+
+        if results is None or any(r is None for r in results):
+            return None
+
+        aggregate = float(np.mean(results))
+
+        if return_per_task:
+            bad_examples = (
+                self._extract_bad_examples(
+                    results, dataset, outputs, targets, failed_examples or 0
+                )
+                if failed_examples
+                else []
+            )
+            return aggregate, results, bad_examples
+
+        if failed_examples is not None and failed_examples > 0:
+            return aggregate, self._extract_bad_examples(
+                results, dataset, outputs, targets, failed_examples
+            )
+
+        return aggregate
+
+    def _compute_scores(
+        self,
+        outputs: list[str | int],
+        targets: list[str | Sequence[str]],
+    ) -> list[float]:
+        """Return one max-over-references BERTScore value per example."""
+        scores = []
+
+        for output, refs in zip(outputs, targets):
+            references = self._as_references(refs)
+            if not references:
+                scores.append(0.0)
+                continue
+
+            output_text = str(output)
+            predictions = [output_text] * len(references)
+            result = self._metric.compute(
+                predictions=predictions,
+                references=references,
+                **self._compute_kwargs_func(predictions, references),
+            )[self._return_parameter]
+
+            scores.append(float(max(result)))
+
+        return scores
+
+    @staticmethod
+    def _as_references(refs: str | Sequence[str]) -> list[str]:
+        """Normalize a single reference or a list of references."""
+        if isinstance(refs, str):
+            return [refs]
+        return [str(ref) for ref in refs if str(ref).strip()]
 
 
 class LLMAsJudge(GenerationMetric):

--- a/coolprompt/evaluator/metrics.py
+++ b/coolprompt/evaluator/metrics.py
@@ -28,6 +28,9 @@ from coolprompt.utils.prompt_templates.llm_as_judge_templates import (
 )
 
 
+DEFAULT_BERTSCORE_MODEL_TYPE = "bert-base-multilingual-cased"
+
+
 class HFEvaluateMetric(ABC):
     """Mixin that delegates metric computation to HuggingFace ``evaluate``."""
 
@@ -387,11 +390,12 @@ class BertScoreMetric(HFEvaluateMetric, GenerationMetric):
     def _get_name():
         return "bertscore"
 
-    def __init__(self):
-        """Load BERTScore with the multilingual base model."""
+    def __init__(self, model_type: str = DEFAULT_BERTSCORE_MODEL_TYPE):
+        """Load BERTScore with the selected model type."""
         super().__init__(self._get_name())
+        self.model_type = model_type
         self._compute_kwargs_func = lambda outputs, targets: {
-            "model_type": "bert-base-multilingual-cased"
+            "model_type": self.model_type
         }
         self._return_parameter = "f1"
 
@@ -403,11 +407,12 @@ class MultiReferenceBertScoreMetric(HFEvaluateMetric, GenerationMetric):
     def _get_name():
         return "multiref_bertscore"
 
-    def __init__(self):
-        """Load BERTScore with the multilingual base model."""
+    def __init__(self, model_type: str = DEFAULT_BERTSCORE_MODEL_TYPE):
+        """Load BERTScore with the selected model type."""
         super().__init__("bertscore")
+        self.model_type = model_type
         self._compute_kwargs_func = lambda outputs, targets: {
-            "model_type": "bert-base-multilingual-cased"
+            "model_type": self.model_type
         }
         self._return_parameter = "f1"
 
@@ -681,6 +686,11 @@ GENERATION_METRIC_NAME_MAPPING = {
 }
 
 
+def _get_bertscore_model_type(kwargs: dict) -> str:
+    """Return the configured BERTScore model type."""
+    return kwargs.get("bertscore_model_type") or DEFAULT_BERTSCORE_MODEL_TYPE
+
+
 def validate_and_create_metric(
     task: Task,
     metric: str | None,
@@ -744,7 +754,15 @@ def validate_and_create_metric(
                     strict_mode=kwargs.get("geval_strict_mode", False),
                 )
             if metric in GENERATION_METRIC_NAME_MAPPING.keys():
-                return GENERATION_METRIC_NAME_MAPPING[metric]()
+                metric_class = GENERATION_METRIC_NAME_MAPPING[metric]
+                if issubclass(
+                    metric_class,
+                    (BertScoreMetric, MultiReferenceBertScoreMetric),
+                ):
+                    return metric_class(
+                        model_type=_get_bertscore_model_type(kwargs)
+                    )
+                return metric_class()
             error_msg = (
                 f"Invalid metric for {task} task: {metric}. "
                 f"Available metrics: {

--- a/coolprompt/utils/load_dataset.py
+++ b/coolprompt/utils/load_dataset.py
@@ -174,6 +174,10 @@ def common_gen_preproc(
 ) -> pd.DataFrame:
     """Preprocessing of CommonGen dataset.
 
+    CommonGen contains multiple valid references for one concept set. Keep
+    them grouped so multi-reference generation metrics can compare a model
+    output against every human reference.
+
     Args:
         sample (DatasetDict): sample of the dataset to preprocess.
         size (Optional[int]): what data size to return.
@@ -184,7 +188,24 @@ def common_gen_preproc(
     """
     data = pd.DataFrame(sample)
 
-    data["input_data"] = data["concepts"].apply(lambda x: str(x))
+    if "concept_set_idx" in data.columns:
+        group_key = "concept_set_idx"
+    else:
+        data["_concepts_group_key"] = data["concepts"].apply(
+            lambda x: tuple(x) if isinstance(x, list) else x
+        )
+        group_key = "_concepts_group_key"
+    grouped = (
+        data.groupby(group_key, sort=False)
+        .agg(
+            concepts=("concepts", "first"),
+            target=("target", list),
+        )
+        .reset_index(drop=True)
+    )
+
+    grouped["input_data"] = grouped["concepts"].apply(lambda x: str(x))
+    data = grouped[["input_data", "target"]]
 
     if size:
         data = data.head(size)
@@ -219,7 +240,7 @@ def load_dataset(
     split: str,
     subset: Optional[str] = None,
     size: Optional[int] = None,
-) -> Tuple[List[str], List[str]]:
+) -> Tuple[List[str], List[str | List[str]]]:
     """Loading preprocessed dataset
 
     Args:
@@ -235,7 +256,7 @@ def load_dataset(
             Defaults to None (full dataset size).
 
     Returns:
-        Tuple[List[str], List[str]]: loaded dataset and targets
+        Tuple[List[str], List[str | List[str]]]: loaded dataset and targets
     """
     match name:
         case "squad_v2":

--- a/docs/API.md
+++ b/docs/API.md
@@ -28,6 +28,11 @@ generation tasks. For each prediction it computes BERTScore F1 against every
 reference and uses the maximum reference score; the final score is the mean
 over examples.
 
+For BERTScore-based metrics, the default underlying model is
+`bert-base-multilingual-cased`. You can override it with
+`bertscore_model_type`; the same model type is used for both `bertscore`
+and `multiref_bertscore`.
+
 You can add a custom metric by implementing the `BaseMetric` interface.
 
 ---

--- a/docs/API.md
+++ b/docs/API.md
@@ -21,7 +21,12 @@ The default optimization method is `hyper_light`.
 
 Supported metric names:
 - classification: `accuracy`, `f1`
-- generation: `bleu`, `rouge`, `meteor`, `bertscore`, `codebertscore`, `em`, `geval`, `llm_as_judge`
+- generation: `bleu`, `rouge`, `meteor`, `bertscore`, `multiref_bertscore`, `codebertscore`, `em`, `geval`, `llm_as_judge`
+
+`multiref_bertscore` is intended for CommonGen-style multi-reference
+generation tasks. For each prediction it computes BERTScore F1 against every
+reference and uses the maximum reference score; the final score is the mean
+over examples.
 
 You can add a custom metric by implementing the `BaseMetric` interface.
 


### PR DESCRIPTION
загружаем таргеты как list[list[str]] 
хоть и контракт ожидает list[str], питон это не проверяет (но может забанить mypy, если решим запустить)
multiref bertscore берет бертскор со всеми таргетами, возвращает максимум